### PR TITLE
Add Rust tests and a CI workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @thunderbird/rust-reviewers

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '30 2 * * *'
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings --cfg tokio_unstable
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build & Test Project
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt, clippy
+
+    - name: Check Formatting
+      run: cargo fmt --all -- --check
+
+    - name: Cargo Cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Build project
+      run: cargo build --all-features
+
+    - name: Test project
+      run: cargo test --all-features --workspace
+
+    - name: Run clippy
+      uses: giraffate/clippy-action@v1
+      with:
+        reporter: 'github-pr-check'
+        clippy_flags: --no-deps --tests
+        filter_mode: nofilter
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build docs
+      env:
+        RUSTDOCFLAGS: -D warnings
+      run: cargo doc --all-features --no-deps --workspace --document-private-items

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "rust-analyzer.server.extraEnv": {
+        "RUSTFLAGS": "--cfg tokio_unstable"
+    },
+    "rust-analyzer.cargo.features": [
+        "line_token",
+    ],
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,7 @@ dependencies = [
  "log",
  "oneshot",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -228,6 +229,27 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ oneshot = "0.1.11"
 async-channel = "2.5.0"
 log = "0.4.21"
 thiserror = "1.0.56"
+
+[dev-dependencies]
+tokio = { version = "1.50.0", features = ["macros", "rt", "time"] }

--- a/README.md
+++ b/README.md
@@ -127,3 +127,13 @@ impl Request {
     }
 }
 ```
+
+# Running tests
+
+Some tests in this crate rely on tokio's [unstable
+API](https://docs.rs/tokio/latest/tokio/index.html#unstable-features).
+Therefore, running them requires the `--cfg tokio_unstable` compiler flag:
+
+```shell
+$ RUSTFLAGS="--cfg tokio_unstable" cargo test --all-features
+```

--- a/src/line_token.rs
+++ b/src/line_token.rs
@@ -65,6 +65,7 @@ struct ReleaseChannel {
 pub struct Line {
     // TODO: We should look into replacing this `RefCell` with a `Mutex` from
     // `async_lock` to make `Line` thread-safe.
+    // https://github.com/thunderbird/operation-queue-rs/issues/2
     channel: RefCell<Option<ReleaseChannel>>,
 }
 

--- a/src/line_token.rs
+++ b/src/line_token.rs
@@ -63,6 +63,8 @@ struct ReleaseChannel {
 /// A [`Line`] from which a [`Token`] can be acquired.
 #[derive(Default)]
 pub struct Line {
+    // TODO: We should look into replacing this `RefCell` with a `Mutex` from
+    // `async_lock` to make `Line` thread-safe.
     channel: RefCell<Option<ReleaseChannel>>,
 }
 
@@ -169,5 +171,109 @@ pub struct Token<'t> {
 impl Drop for Token<'_> {
     fn drop(&mut self) {
         self.line.release();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::time::Duration;
+
+    use super::*;
+
+    fn get_token(line: &Line) -> Token<'_> {
+        match line.try_acquire_token() {
+            AcquireOutcome::Success(token) => token,
+            AcquireOutcome::Failure(_) => panic!("expected a token from try_acquire_token()"),
+        }
+    }
+
+    #[test]
+    fn acquire_token() {
+        let line = Line::new();
+
+        let _token = get_token(&line);
+
+        match line.try_acquire_token() {
+            AcquireOutcome::Success(_) => {
+                panic!("should not be able to acquire the line while the token is in scope")
+            }
+            AcquireOutcome::Failure(_) => (),
+        }
+    }
+
+    #[test]
+    fn token_out_of_scope() {
+        let line = Line::new();
+
+        {
+            let _token = get_token(&line);
+
+            match line.try_acquire_token() {
+                AcquireOutcome::Success(_) => {
+                    panic!("should not be able to acquire the line while the token is in scope")
+                }
+                AcquireOutcome::Failure(_) => (),
+            }
+        }
+
+        match line.try_acquire_token() {
+            AcquireOutcome::Success(_) => (),
+            AcquireOutcome::Failure(_) => {
+                panic!("expected a token now that the previous token has been dropped")
+            }
+        }
+    }
+
+    #[test]
+    fn or_token() {
+        let line = Line::new();
+
+        let token = get_token(&line);
+
+        match line.try_acquire_token().or_token(Some(token)) {
+            AcquireOutcome::Success(_) => (),
+            AcquireOutcome::Failure(_) => panic!("we should have kept our token"),
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn line_release_on_drop() {
+        let line = Line::new();
+
+        // A mutable variable that will act as the test's success flag and will
+        // only be true if it succeeds.
+        let mut success = false;
+
+        // Acquire the line's token, sleep for a bit (10ms) and then drop it.
+        // The reason we sleep here is to give some time to `wait_for_line` to
+        // try (and fail) to acquire the line's token before we drop it.
+        async fn acquire_sleep_and_drop(line: &Line) {
+            let _token = get_token(&line);
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        // Try (and fail) to acquire the token, then wait for the line to become
+        // available again. This function sets the success flag.
+        async fn wait_for_line(line: &Line, success: &mut bool) {
+            let shared = match line.try_acquire_token() {
+                AcquireOutcome::Success(_) => {
+                    panic!("should not be able to acquire the line while the token is in scope")
+                }
+                AcquireOutcome::Failure(shared) => shared,
+            };
+
+            shared.await.unwrap();
+            *success = true;
+        }
+
+        // Run both futures in parallel. `biased;` ensures the futures are
+        // polled in order (meaning `acquire_sleep_and_drop` is run first).
+        tokio::join! {
+            biased;
+            acquire_sleep_and_drop(&line),
+            wait_for_line(&line, &mut success),
+        };
+
+        assert!(success)
     }
 }

--- a/src/operation_queue.rs
+++ b/src/operation_queue.rs
@@ -72,15 +72,15 @@ pub struct OperationQueue {
     channel_sender: Sender<Box<dyn ErasedQueuedOperation>>,
     channel_receiver: Receiver<Box<dyn ErasedQueuedOperation>>,
     runners: RefCell<Vec<Arc<Runner>>>,
-    spawn_task: fn(fut: Box<dyn Future<Output = ()>>),
+    spawn_task: fn(fut: Pin<Box<dyn Future<Output = ()>>>),
 }
 
 impl OperationQueue {
     /// Creates a new operation queue.
     ///
     /// The function provided as argument is used when spawning new runners,
-    /// e.g. `tokio::task::spawn`. It must not be blocking.
-    pub fn new(spawn_task: fn(fut: Box<dyn Future<Output = ()>>)) -> OperationQueue {
+    /// e.g. `tokio::task::spawn_local`. It must not be blocking.
+    pub fn new(spawn_task: fn(fut: Pin<Box<dyn Future<Output = ()>>>)) -> OperationQueue {
         let (snd, rcv) = async_channel::unbounded();
 
         OperationQueue {
@@ -104,7 +104,7 @@ impl OperationQueue {
 
         for i in 0..runners {
             let runner = Runner::new(i, self.channel_receiver.clone());
-            (self.spawn_task)(Box::new(runner.clone().run()));
+            (self.spawn_task)(Box::pin(runner.clone().run()));
             self.runners.borrow_mut().push(runner);
         }
 
@@ -288,5 +288,129 @@ impl Runner {
     /// Gets the runner's current state.
     fn state(&self) -> RunnerState {
         self.state.get()
+    }
+}
+
+#[cfg(test)]
+// For simplicity, we run our async tests using tokio's local runtime using the
+// unstable "local" value for the `flavor` argument in `tokio::test`. Because it
+// comes from tokio's unstable API, we need to supply the `tokio_unstable` cfg
+// condition, which in turn triggers a warning from within the `tokio::test`
+// macro about an unexpected cfg condition name.
+#[allow(unexpected_cfgs)]
+mod tests {
+    use super::*;
+
+    use async_channel::Sender;
+    use tokio::time::Duration;
+
+    fn new_queue() -> OperationQueue {
+        OperationQueue::new(|fut| {
+            let _ = tokio::task::spawn_local(fut);
+        })
+    }
+
+    #[tokio::test(flavor = "local")]
+    async fn start_queue() {
+        let queue = new_queue();
+
+        queue.start(5).unwrap();
+        assert_eq!(queue.runners.borrow().len(), 5);
+
+        // We need to await something to give the runners a chance to start
+        // their loops.
+        tokio::time::sleep(Duration::from_millis(0)).await;
+        assert!(queue.idle());
+    }
+
+    #[tokio::test(flavor = "local")]
+    async fn stop_queue() {
+        let queue = new_queue();
+
+        queue.start(5).unwrap();
+
+        // We need to await something to give the runners a chance to start
+        // their loops.
+        tokio::time::sleep(Duration::from_millis(0)).await;
+        assert!(queue.idle());
+
+        queue.stop().await;
+        assert!(!queue.running());
+        assert!(queue.channel_receiver.is_closed());
+
+        match queue.start(1) {
+            Ok(_) => panic!("we should not be able to start the queue after stopping it"),
+            Err(err) if matches!(err, Error::Stopped) => (),
+            Err(_) => panic!("unexpected error"),
+        }
+
+        // Try to enqueue a dummy operation to make sure it fails.
+        #[derive(Debug)]
+        struct Operation {}
+        impl QueuedOperation for Operation {
+            async fn perform(&self) {}
+        }
+
+        let op = Box::new(Operation {});
+        match queue.enqueue(op).await {
+            Ok(_) => panic!("we should not be able to enqueue operations after stopping the queue"),
+            Err(err) if matches!(err, Error::Sender) => (),
+            Err(_) => panic!("unexpected error"),
+        }
+    }
+
+    #[tokio::test(flavor = "local")]
+    async fn operation_order() {
+        // A simple operation with a numerical ID that sends its own ID through
+        // a channel.
+        #[derive(Debug)]
+        struct Operation {
+            id: u8,
+            sender: Sender<u8>,
+        }
+        impl QueuedOperation for Operation {
+            async fn perform(&self) {
+                self.sender.send(self.id).await.unwrap();
+            }
+        }
+
+        let queue = new_queue();
+
+        // Create a channel the operations can use to send us their ID.
+        let (sender, receiver) = async_channel::unbounded();
+
+        // Enqueue a couple of operations.
+        queue
+            .enqueue(Box::new(Operation {
+                id: 1,
+                sender: sender.clone(),
+            }))
+            .await
+            .unwrap();
+
+        queue
+            .enqueue(Box::new(Operation {
+                id: 2,
+                sender: sender.clone(),
+            }))
+            .await
+            .unwrap();
+
+        // Start exactly one runner so we can check that operations run in
+        // order.
+        queue.start(1).unwrap();
+
+        // We need to await something to give the runner a chance to start and
+        // perform operations.
+        tokio::time::sleep(Duration::from_millis(0)).await;
+
+        // Check that we got both IDs in order.
+        let id = receiver.recv().await.unwrap();
+        assert_eq!(id, 1);
+        let id = receiver.recv().await.unwrap();
+        assert_eq!(id, 2);
+
+        // For bonus points: the queue should be fully idle now.
+        assert!(queue.idle());
     }
 }

--- a/src/operation_queue.rs
+++ b/src/operation_queue.rs
@@ -306,7 +306,7 @@ mod tests {
 
     fn new_queue() -> OperationQueue {
         OperationQueue::new(|fut| {
-            let _ = tokio::task::spawn_local(fut);
+            _ = tokio::task::spawn_local(fut);
         })
     }
 
@@ -340,7 +340,7 @@ mod tests {
 
         match queue.start(1) {
             Ok(_) => panic!("we should not be able to start the queue after stopping it"),
-            Err(err) if matches!(err, Error::Stopped) => (),
+            Err(Error::Stopped) => (),
             Err(_) => panic!("unexpected error"),
         }
 
@@ -354,7 +354,7 @@ mod tests {
         let op = Box::new(Operation {});
         match queue.enqueue(op).await {
             Ok(_) => panic!("we should not be able to enqueue operations after stopping the queue"),
-            Err(err) if matches!(err, Error::Sender) => (),
+            Err(Error::Sender) => (),
             Err(_) => panic!("unexpected error"),
         }
     }


### PR DESCRIPTION
According to cargo-tarpaulin, the coverage with these tests is 90%. Most of the lines that aren't being hit are just logs (and a couple of cases that *should* not be possible in practice but that impossibility isn't trivially translatable in code).

The CI workflow is copied from ews-rs, with the additional `--cfg tokio_unstable` compiler flag to support the tests in `operation_queue.rs` (see the comment in that file).