### PR TITLE
Annotate `Token` as `must_use`

### DIFF
--- a/src/line_token.rs
+++ b/src/line_token.rs
@@ -121,6 +121,7 @@ impl Line {
 }
 
 /// The outcome from trying to acquire a [`Token`] for a [`Line`].
+#[must_use = "if the token is unused the line will immediately release again"]
 pub enum AcquireOutcome<'ao> {
     /// The line could be acquired and returned a token to hold on to.
     ///
@@ -165,6 +166,7 @@ impl<'ao> AcquireOutcome<'ao> {
 ///
 /// The [`Line`] is automatically released when this token goes out of scope and
 /// is dropped.
+#[must_use = "if unused the line will immediately release again"]
 pub struct Token<'t> {
     line: &'t Line,
 }


### PR DESCRIPTION
I looked at some of the [other annotations](https://doc.rust-lang.org/src/std/sync/poison/mutex.rs.html#270) used by `MutexGuard`, but they don't seem to apply here.

Based on #1 for tests and CI.
