### PR TITLE
Add a method to soft-check a line's status

### DIFF
--- a/src/line_token.rs
+++ b/src/line_token.rs
@@ -59,6 +59,11 @@ struct ReleaseChannel {
     receiver: Shared<Receiver<()>>,
 }
 
+pub enum LineStatus {
+    Free,
+    Busy(Shared<Receiver<()>>),
+}
+
 /// A [`Line`] from which a [`Token`] can be acquired.
 ///
 /// # Thread safety
@@ -84,6 +89,22 @@ impl Line {
     pub fn new() -> Line {
         Line {
             channel: Default::default(),
+        }
+    }
+
+    /// Retrieve the current status of the [`Line`], i.e. whether it's currently
+    /// free or not.
+    ///
+    /// Unlike [`try_acquire_token`], this method does not attempt to lock the
+    /// line if it's free, and does not generate a [`Token`]. If the line is
+    /// busy, it returns a future the consumer can use to wait till the line
+    /// becomes free again.
+    ///
+    /// [`try_acquire_token`]: Self::try_acquire_token
+    pub async fn status(&self) -> LineStatus {
+        match self.channel.lock().await.as_ref() {
+            Some(channel) => LineStatus::Busy(channel.receiver.clone()),
+            None => LineStatus::Free,
         }
     }
 

--- a/src/line_token.rs
+++ b/src/line_token.rs
@@ -59,8 +59,13 @@ struct ReleaseChannel {
     receiver: Shared<Receiver<()>>,
 }
 
+/// The current status of a line.
 pub enum LineStatus {
+    /// The line is free.
     Free,
+
+    /// The line is busy, and the nested future can be used to wait till the
+    /// line becomes free again.
     Busy(Shared<Receiver<()>>),
 }
 

--- a/src/line_token.rs
+++ b/src/line_token.rs
@@ -317,4 +317,52 @@ mod tests {
 
         assert!(success)
     }
+
+    /// Tests the [`Line::status`] method.
+    ///
+    /// This test behaves a lot like [`line_release_on_drop`], except it waits
+    /// for the line to be freed via [`Line::status`] rather than
+    /// [`Line::try_acquire_token`].
+    #[tokio::test(flavor = "current_thread")]
+    async fn line_status() {
+        let line = Line::new();
+        assert!(matches!(line.status().await, LineStatus::Free));
+
+        // A mutable variable that will act as the test's success flag and will
+        // only be true if it succeeds.
+        let mut success = false;
+
+        // Acquire the line's token, sleep for a bit (10ms) and then drop it.
+        // The reason we sleep here is to give some time to `wait_for_line` to
+        // try (and fail) to acquire the line's token before we drop it.
+        async fn acquire_sleep_and_drop(line: &Line) {
+            let _token = get_token(&line).await;
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        // Check that the line is busy, then wait for the line to become
+        // available again. This function sets the success flag.
+        async fn wait_for_line(line: &Line, success: &mut bool) {
+            let shared = match line.status().await {
+                LineStatus::Free => {
+                    panic!("line should be busy")
+                }
+                LineStatus::Busy(shared) => shared,
+            };
+
+            shared.await.unwrap();
+            *success = true;
+        }
+
+        // Run both futures in parallel. `biased;` ensures the futures are
+        // polled in order (meaning `acquire_sleep_and_drop` is run first).
+        tokio::join! {
+            biased;
+            acquire_sleep_and_drop(&line),
+            wait_for_line(&line, &mut success),
+        };
+
+        assert!(matches!(line.status().await, LineStatus::Free));
+        assert!(success)
+    }
 }


### PR DESCRIPTION
The idea is to introduce a way to "soft" check the line's status (i.e. check it without trying to acquire a token), so we can block new requests that may come in while the line is busy, e.g. https://hg-edge.mozilla.org/try-comm-central/diff/d38b84c416024186067c25ec4236c2b52b202c99/rust/protocol_shared/src/operation_sender.rs).